### PR TITLE
Adding tunnel table indirection to the pipeline

### DIFF
--- a/dash-pipeline/bmv2/dash_inbound.p4
+++ b/dash-pipeline/bmv2/dash_inbound.p4
@@ -71,13 +71,6 @@ control inbound(inout headers_t hdr,
         ConntrackOut.apply(hdr, meta);
 #endif //PNA_CONNTRACK
 
-        vxlan_encap(hdr,
-                    meta.encap_data.underlay_dmac,
-                    meta.encap_data.underlay_smac,
-                    meta.encap_data.underlay_dip,
-                    meta.encap_data.underlay_sip,
-                    hdr.ethernet.dst_addr,
-                    meta.encap_data.vni);
     }
 }
 

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -3,20 +3,27 @@
 
 #include "dash_headers.p4"
 
+enum bit<16> direction_t {
+    INVALID = 0,
+    OUTBOUND = 1,
+    INBOUND = 2
+}
+
+enum bit<16> encap_type_t {
+    INVALID = 0,
+    VXLAN = 1,
+    NVGRE = 2
+}
+
 struct encap_data_t {
     bit<24> vni;
     bit<24> dest_vnet_vni;
+    encap_type_t type;
     IPv4Address underlay_sip;
     IPv4Address underlay_dip;
     EthernetAddress underlay_smac;
     EthernetAddress underlay_dmac;
     EthernetAddress overlay_dmac;
-}
-
-enum bit<16> direction_t {
-    INVALID = 0,
-    OUTBOUND = 1,
-    INBOUND = 2
 }
 
 struct conntrack_data_t {
@@ -36,13 +43,14 @@ struct metadata_t {
     direction_t direction;
     encap_data_t encap_data;
     EthernetAddress eni_addr;
-    bit<16> eni_id;
     eni_data_t eni_data;
-    bit<16> inbound_vm_id;
-    bit<8> appliance_id;
-    bit<1> is_dst_ip_v6;
     IPv4ORv6Address dst_ip_addr;
     conntrack_data_t conntrack_data;
+    bit<16> eni_id;
+    bit<16> inbound_vm_id;
+    bit<16> tunnel_id;
+    bit<8> appliance_id;
+    bit<1> is_dst_ip_v6;
 }
 
 #endif /* _SIRIUS_METADATA_P4_ */

--- a/dash-pipeline/bmv2/dash_outbound.p4
+++ b/dash-pipeline/bmv2/dash_outbound.p4
@@ -45,8 +45,8 @@ control outbound(inout headers_t hdr,
         counters = routing_counter;
     }
 
-    action set_tunnel_mapping(IPv4Address underlay_dip,
-                              EthernetAddress overlay_dmac,
+    action set_tunnel_mapping(EthernetAddress overlay_dmac,
+                              bit<16> tunnel_id,
                               bit<1> use_dst_vni) {
         /*
            if (use_dst_vni)
@@ -56,7 +56,7 @@ control outbound(inout headers_t hdr,
         */
         meta.encap_data.vni = meta.encap_data.vni * (bit<24>)(~use_dst_vni) + meta.encap_data.dest_vnet_vni * (bit<24>)use_dst_vni;
         meta.encap_data.overlay_dmac = overlay_dmac;
-        meta.encap_data.underlay_dip = underlay_dip;
+        meta.tunnel_id = tunnel_id;
     }
 
     direct_counter(CounterType.packets_and_bytes) ca_to_pa_counter;
@@ -104,14 +104,6 @@ control outbound(inout headers_t hdr,
         switch (routing.apply().action_run) {
             route_vnet: {
                 ca_to_pa.apply();
-
-                vxlan_encap(hdr,
-                            meta.encap_data.underlay_dmac,
-                            meta.encap_data.underlay_smac,
-                            meta.encap_data.underlay_dip,
-                            meta.encap_data.underlay_sip,
-                            meta.encap_data.overlay_dmac,
-                            meta.encap_data.vni);
              }
          }
     }


### PR DESCRIPTION
eni_to_vm table is already removed in https://github.com/Azure/DASH/pull/137. With the current changes inbound tunnel-id is driven from the ENI table