### PR TITLE
Adding vnet table to the pipeline

### DIFF
--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -36,6 +36,8 @@ struct metadata_t {
     direction_t direction;
     encap_data_t encap_data;
     EthernetAddress eni_addr;
+    bit<16> vnet_id;
+    bit<16> dst_vnet_id;
     bit<16> eni_id;
     eni_data_t eni_data;
     bit<16> inbound_vm_id;

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -88,13 +88,16 @@ control dash_ingress(inout headers_t hdr,
                          bit<32> flows,
                          bit<1> admin_state,
                          IPv4Address vm_underlay_dip,
-                         bit<24> vm_vni) {
+                         bit<24> vm_vni,
+                         bit<16> vnet_id) {
         meta.eni_data.cps            = cps;
         meta.eni_data.pps            = pps;
         meta.eni_data.flows          = flows;
         meta.eni_data.admin_state    = admin_state;
         meta.encap_data.underlay_dip = vm_underlay_dip;
+        /* vm_vni used in the inbound direction */
         meta.encap_data.vni          = vm_vni;
+        meta.vnet_id                 = vnet_id;
     }
 
     @name("eni|dash")


### PR DESCRIPTION
    - ENI table drives vnet-id for the VNET table as specified in the GNMI schema
    - Route lookup drives destination vnet-id for the VNET table lookup
    - Removing redundant eni_to_vni table